### PR TITLE
Prepend message with log-level

### DIFF
--- a/src/huon/log.clj
+++ b/src/huon/log.clj
@@ -3,7 +3,8 @@
 (defmacro ^:private log [level args]
   `(log* ~(str *ns*)
          ~level
-         #(clojure.string/join " " ~(mapv (fn [x] `(str ~x)) args))))
+         #(str "[" (clojure.string/upper-case (name ~level))  "] "
+               (clojure.string/join " " ~(mapv (fn [x] `(str ~x)) args)))))
 
 (defmacro debug
   "Evaluate and log args if level >= :debug"

--- a/test/expected.log
+++ b/test/expected.log
@@ -1,14 +1,14 @@
- [  0.018s] [huon.tests] debug 0
- [  0.020s] [huon.tests] info 0
- [  0.020s] [huon.tests] warn 0
- [  0.020s] [huon.tests] error 0
- [  0.021s] [huon.tests] info 1
- [  0.021s] [huon.tests] warn 1
- [  0.021s] [huon.tests] error 1
- [  0.021s] [huon.tests] warn 2
- [  0.021s] [huon.tests] error 2
- [  0.021s] [huon.tests] error 3
- [  0.022s] [huon.tests] {:foo "bar", :baz 42}
- [  0.022s] [huon.tests] (a b c d foo yadda-yadda)
- [  0.023s] [huon.tests] [object Object]
- [  0.023s] [huon.tests] should see this
+ [  0.018s] [huon.tests] [DEBUG] debug 0
+ [  0.020s] [huon.tests] [INFO] info 0
+ [  0.020s] [huon.tests] [WARN] warn 0
+ [  0.020s] [huon.tests] [ERROR] error 0
+ [  0.021s] [huon.tests] [INFO] info 1
+ [  0.021s] [huon.tests] [WARN] warn 1
+ [  0.021s] [huon.tests] [ERROR] error 1
+ [  0.021s] [huon.tests] [WARN] warn 2
+ [  0.021s] [huon.tests] [ERROR] error 2
+ [  0.021s] [huon.tests] [ERROR] error 3
+ [  0.022s] [huon.tests] [DEBUG] {:foo "bar", :baz 42}
+ [  0.022s] [huon.tests] [DEBUG] (a b c d foo yadda-yadda)
+ [  0.023s] [huon.tests] [DEBUG] [object Object]
+ [  0.023s] [huon.tests] [INFO] should see this


### PR DESCRIPTION
As discussed in issue #3

new format:
```
[ 20.422s] [foo.core] [INFO] some info
```