### PR TITLE
WIP: Show linenumbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Add `[org.harto/huon "0.2.1"]` as a dependency in `project.clj`.
 
 Output:
 ```
- [  0.021s] [foo.bar] hello world
+ [  0.021s] [foo.bar:11] [INFO] hello world
 ```
 
 Available macros are `debug`, `info`, `warn` and `error`.

--- a/src/huon/log.clj
+++ b/src/huon/log.clj
@@ -1,27 +1,33 @@
 (ns huon.log)
 
 (defmacro ^:private log [level args]
-  `(log* ~(str *ns*)
-         ~level
-         #(str "[" (clojure.string/upper-case (name ~level))  "] "
-               (clojure.string/join " " ~(mapv (fn [x] `(str ~x)) args)))))
+  (let [origin-meta# (-> &form meta :origin)
+        origin#      (str (:ns origin-meta#) ":" (:line origin-meta#))]
+    `(log* ~(str *ns*)
+           ~level
+           #(str "[" ~origin# "] "
+                 "[" (clojure.string/upper-case (name ~level))  "] "
+                 (clojure.string/join " " ~(mapv (fn [x] `(str ~x)) args))))))
+
+(defn- origin-meta [form]
+  {:origin {:ns *ns* :line (:line (meta form))}})
 
 (defmacro debug
   "Evaluate and log args if level >= :debug"
   [& args]
-  `(log :debug ~args))
+  (with-meta `(log :debug ~args) (origin-meta &form)))
 
 (defmacro info
   "Evaluate and log args if level >= :info"
   [& args]
-  `(log :info ~args))
+  (with-meta `(log :info ~args) (origin-meta &form)))
 
 (defmacro warn
   "Evaluate and log args if level >= :warn"
   [& args]
-  `(log :warn ~args))
+  (with-meta `(log :warn ~args) (origin-meta &form)))
 
 (defmacro error
   "Evaluate and log args if level >= :error"
   [& args]
-  `(log :error ~args))
+  (with-meta `(log :error ~args) (origin-meta &form)))

--- a/src/huon/log.cljs
+++ b/src/huon/log.cljs
@@ -15,6 +15,7 @@
   "Start capturing console output. Apps that want to display log output should
   call this function, but libraries that depend on Huon for logging should not."
   []
+  (set! (.-showLoggerName (.getFormatter console)) false)
   (.setCapturing console true))
 
 (def ^:private levels

--- a/test/expected.log
+++ b/test/expected.log
@@ -1,14 +1,14 @@
- [  0.018s] [huon.tests] [DEBUG] debug 0
- [  0.020s] [huon.tests] [INFO] info 0
- [  0.020s] [huon.tests] [WARN] warn 0
- [  0.020s] [huon.tests] [ERROR] error 0
- [  0.021s] [huon.tests] [INFO] info 1
- [  0.021s] [huon.tests] [WARN] warn 1
- [  0.021s] [huon.tests] [ERROR] error 1
- [  0.021s] [huon.tests] [WARN] warn 2
- [  0.021s] [huon.tests] [ERROR] error 2
- [  0.021s] [huon.tests] [ERROR] error 3
- [  0.022s] [huon.tests] [DEBUG] {:foo "bar", :baz 42}
- [  0.022s] [huon.tests] [DEBUG] (a b c d foo yadda-yadda)
- [  0.023s] [huon.tests] [DEBUG] [object Object]
- [  0.023s] [huon.tests] [INFO] should see this
+ [  0.018s] [huon.tests:14] [DEBUG] debug 0
+ [  0.020s] [huon.tests:15] [INFO] info 0
+ [  0.020s] [huon.tests:16] [WARN] warn 0
+ [  0.020s] [huon.tests:17] [ERROR] error 0
+ [  0.021s] [huon.tests:15] [INFO] info 1
+ [  0.021s] [huon.tests:16] [WARN] warn 1
+ [  0.021s] [huon.tests:17] [ERROR] error 1
+ [  0.021s] [huon.tests:16] [WARN] warn 2
+ [  0.021s] [huon.tests:17] [ERROR] error 2
+ [  0.021s] [huon.tests:17] [ERROR] error 3
+ [  0.022s] [huon.tests:25] [DEBUG] {:foo "bar", :baz 42}
+ [  0.022s] [huon.tests:26] [DEBUG] (a b c d foo yadda-yadda)
+ [  0.023s] [huon.tests:27] [DEBUG] [object Object]
+ [  0.023s] [huon.tests:31] [INFO] should see this


### PR DESCRIPTION
This PR ensures that the origin of a log-statement (`ns:line`) is shown:

```
 [  0.226s] [foo.core:51] [DEBUG] some debug
 [  0.227s] [foo.main:34] [ERROR] some error
```

While just appending another block would have been an option (eg `[  0.227s] [foo.main] [ERROR] [foo.main:34] some error`). This would take up quite some space and would've (the logger-name being the namespace) duplicate information.  
Instead the logger-name was disabled and the `ns:line` prepended to the message.

(ignore changes to `deps.edn` - this is for testing purpose).  

Is this something to workout?

Tasks:
- [x] fix test
- [x] reflect new format in README
- [x] test in browser (currently tested with node)
- [x] remove deps.edn

Test via demo-branch:
```bash
# browser
$ clj -Sdeps "{:deps {otarta {:git/url \"git@github.com:eval/huon.git\" :sha \"dd26792114d2a12e715d488a15d2509c78553e15\"}}}}" -m cljs.main -e '(require (quote [huon.log :as log]))' --repl
cljs.user=> (log/error "some error")
;; shows "log:[cljs.user:1] [ERROR] some error" in browser's console

# node
$ clj -Sdeps "{:deps {otarta {:git/url \"git@github.com:eval/huon.git\" :sha \"dd26792114d2a12e715d488a15d2509c78553e15\"}}}}" -m cljs.main -re node -e '(require (quote [huon.log :as log]))(log/enable!)' --repl
cljs.user=> (log/info "some error")
 [  8.767s] [cljs.user:1] [INFO] some error
nil
```