### PR TITLE
Remove dependency on goog.debug.Logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # Huon [![Build Status](https://travis-ci.org/harto/huon.svg?branch=master)](https://travis-ci.org/harto/huon)
 
-A logging library for ClojureScript that wraps [`goog.debug.Logger`](https://google.github.io/closure-library/api/goog.debug.Logger.html).
+A console logging library for ClojureScript.
 
 
 ## Goals
 
- * Leverage GClosure functionality
  * Lazy message evaluation
  * Simple API
 
@@ -17,7 +16,7 @@ A logging library for ClojureScript that wraps [`goog.debug.Logger`](https://goo
 
 ## Installation
 
-Add `[org.harto/huon "0.5.1"]` as a dependency in `project.clj`.
+Add `[org.harto/huon "1.0.0-SNAPSHOT"]` as a dependency in `project.clj`.
 
 
 ## Usage
@@ -26,11 +25,8 @@ Add `[org.harto/huon "0.5.1"]` as a dependency in `project.clj`.
 (ns foo.bar
   (:require [huon.log :as log]))
 
-;; required; once per app
-(log/enable!)
-
 ;; optional; defaults to :warn
-(log/set-root-level! :info)
+(log/configure! {:root-level :info})
 
 (log/debug "an invisible message")
 (log/info "hello" "world")
@@ -38,10 +34,21 @@ Add `[org.harto/huon "0.5.1"]` as a dependency in `project.clj`.
 
 Output:
 ```
- [  0.021s] [foo.bar:11] [INFO] hello world
+[foo.bar:8] hello world
 ```
 
-Available macros are `debug`, `info`, `warn` and `error`.
+Available logging macros are `debug`, `info`, `warn` and `error`.
+
+Other API functions are:
+ - `(configure! opts)` - set logging configuration according to options
+ - `(set-root-level! level)` - reset the root logger level (e.g. `(set-root-level! :error)`)
+ - `(set-level! logger-name level)` - reset a logger level (e.g. `(set-level! "foo.bar" :warn)`)
+
+Configuration options are:
+ - `:show-level?` - whether to print the log level alongside each message
+ - `:format` - a function to customize formatting of each message argument
+ - `:root-level` - the global logging threshold (default: `:warn`)
+ - `:logger-levels` - a mapping of namespace names to log levels (e.g. `{"foo" :info, "foo.bar" :debug}`)
 
 
 ## Development

--- a/bin/diff-logs
+++ b/bin/diff-logs
@@ -1,8 +1,3 @@
 #!/usr/bin/env bash
 set -euo pipefail
-
-elide_timestamps() {
-  sed -E 's/\[ *[0-9]+\.[0-9]+s\]/[...]/' "$@"
-}
-
-diff --side-by-side <(elide_timestamps "$1") <(elide_timestamps "$2")
+diff --side-by-side "$1" "$2"

--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,5 @@
-(defproject org.harto/huon "0.5.1"
-  :description "ClojureScript interface to goog.debug.Logger"
+(defproject org.harto/huon "1.0.0-SNAPSHOT"
+  :description "ClojureScript wrapper around console logger"
   :url "https://github.com/harto/huon"
   :license {:name "MIT"
             :url "https://github.com/harto/huon/blob/master/LICENSE"}

--- a/test/expected.log
+++ b/test/expected.log
@@ -1,14 +1,22 @@
- [  0.018s] [huon.tests:12] [DEBUG] debug 0
- [  0.020s] [huon.tests:13] [INFO] info 0
- [  0.020s] [huon.tests:14] [WARN] warn 0
- [  0.020s] [huon.tests:15] [ERROR] error 0
- [  0.021s] [huon.tests:13] [INFO] info 1
- [  0.021s] [huon.tests:14] [WARN] warn 1
- [  0.021s] [huon.tests:15] [ERROR] error 1
- [  0.021s] [huon.tests:14] [WARN] warn 2
- [  0.021s] [huon.tests:15] [ERROR] error 2
- [  0.021s] [huon.tests:15] [ERROR] error 3
- [  0.022s] [huon.tests:23] [DEBUG] {:foo "bar", :baz 42}
- [  0.022s] [huon.tests:24] [DEBUG] (a b c d foo yadda-yadda)
- [  0.023s] [huon.tests:25] [DEBUG] [object Object]
- [  0.023s] [huon.tests:29] [INFO] should see this
+[huon.tests:12] (log/debug …) logs :debug messages
+[huon.tests:13] (log/info …) logs :debug messages
+[huon.tests:14] (log/warn …) logs :debug messages
+[huon.tests:15] (log/error …) logs :debug messages
+[huon.tests:17] (log/log :debug …) logs :debug messages
+[huon.tests:13] (log/info …) logs :info messages
+[huon.tests:14] (log/warn …) logs :info messages
+[huon.tests:15] (log/error …) logs :info messages
+[huon.tests:17] (log/log :info …) logs :info messages
+[huon.tests:14] (log/warn …) logs :warn messages
+[huon.tests:15] (log/error …) logs :warn messages
+[huon.tests:17] (log/log :warn …) logs :warn messages
+[huon.tests:15] (log/error …) logs :error messages
+[huon.tests:17] (log/log :error …) logs :error messages
+[huon.tests:25] {:foo "bar", :baz 42}
+[huon.tests:26] (a b c d foo yadda-yadda)
+[huon.tests:27] [object Object]
+[huon.tests:32] [DEBUG] <- it's debug
+[huon.tests:32] [INFO] <- it's info
+[huon.tests:32] [WARN] <- it's warn
+[huon.tests:32] [ERROR] <- it's error
+[huon.tests:37] should see this

--- a/test/huon/tests.cljs
+++ b/test/huon/tests.cljs
@@ -2,32 +2,39 @@
   (:require [huon.log :as log]
             [huon.tests-2]))
 
-(enable-console-print!)
-(log/enable!)
+(log/configure! {:show-level? false
+                 :format str})
 
 (defn ^:export main []
   ;; check messages not logged below threshold
-  (doseq [[i level] (map-indexed vector [:debug :info :warn :error])]
-    (log/set-root-level! level)
-    (log/debug "debug" i)
-    (log/info "info" i)
-    (log/warn "warn" i)
-    (log/error "error" i))
+  (doseq [level [:debug :info :warn :error]]
+    (log/configure! {:root-level level})
+    (log/debug "(log/debug …) logs" level "messages")
+    (log/info "(log/info …) logs" level "messages")
+    (log/warn "(log/warn …) logs" level "messages")
+    (log/error "(log/error …) logs" level "messages")
+    ;; specify log level at runtime
+    (log/log level (str "(log/log " level " …)") "logs" level "messages"))
 
   ;; check messages not evaluated below threshold
   (log/set-root-level! :error)
-  (log/info (throw (js/Error. "shouldn't get here")))
+  (log/info (throw (js/Error. "shouldn't be evaluated")))
 
   ;; check formatting of various objects
   (log/set-root-level! :debug)
   (log/debug {:foo "bar" :baz 42})
   (log/debug '(a b c d foo yadda-yadda))
-  (log/debug #js {:foo 42})
+  (log/debug #js{:foo 42})
+
+  ;; show log level in message
+  (log/configure! {:show-level? true})
+  (doseq [level [:debug :info :warn :error]]
+    (log/log level "<- it's" (name level)))
+  (log/configure! {:show-level? false})
 
   ;; check level override
   (log/set-level! "huon.tests-2" :warn)
   (log/info "should see this")
-  (huon.tests-2/log-info "shouldn't see this")
-  )
+  (huon.tests-2/log-info "shouldn't see this"))
 
 (set! *main-cli-fn* main)


### PR DESCRIPTION
The GClosure logging library is slightly restrictive in that it can only log a single (string) argument per message. This is fine when we only want to print a simple string representation, but developers may want to use utilities like [cljs-devtools][cljs-devtools] to inspect logged objects.

To support this usecase, we need to be able pass objects directly to `console`, unformatted, and so this changeset removes the dependency on goog.debug.Logger.

To support this, I added a small set of configuration options and implemented a basic logger hierarchy. The configuration defaults mostly match the original API.

One notable backward-incompatible difference is that the timestamp is no longer emitted in log messages, which is something we could add back if needed.

 [cljs-devtools]: https://github.com/binaryage/cljs-devtools